### PR TITLE
ie10 이하에서만 작동하는 옵션이 있으면 어떨까요?

### DIFF
--- a/conf/info.xml
+++ b/conf/info.xml
@@ -23,5 +23,17 @@
 				<title xml:lang="en">CSS and JS</title>
 			</options>
 		</var>
+		<var name="zip_target" type="select">
+			<title xml:lang="ko">적용할 브라우저</title>
+			<title xml:lang="en">Target Browser</title>
+			<options value="ie">
+				<title xml:lang="ko">IE 10이하</title>
+				<title xml:lang="en">IE 10 below</title>
+			</options>
+			<options value="all">
+				<title xml:lang="ko">모든 브라우저</title>
+				<title xml:lang="en">all browser</title>
+			</options>
+		</var>
 	</extra_vars>
 </addon>

--- a/zipperupper.addon.php
+++ b/zipperupper.addon.php
@@ -11,6 +11,9 @@ if(!defined('__XE__')) exit;
 if($called_position !== 'before_display_content') return;
 if(version_compare(PHP_VERSION, '5.3', '<')) return;
 
+if($addon_info->zip_target === 'ie' && preg_match('/MSIE (6|7|8|9|10)/',$_SERVER['HTTP_USER_AGENT']) === 0)
+    return;
+
 include_once 'zipperupper.class.php';
 $zipperupper = new ZipperUpper();
 $zipperupper->zipUp($addon_info->zip_type);


### PR DESCRIPTION
문제가 발생하는 ie10 이하에서만 작동하는 옵션이 있으면 어떨까 해서 PR을 올려봅니다.

보통은 페이지별로(메인, 글목록, 글쓰기, 글읽기 등등...) CSS/JS가 조금씩 차이가 나는데요, 이 경우 zipperupper를 일괄적으로 적용해 버릴 경우, 페이지를 전환할때 마다 모든 CSS/JS를 새로 다운받아야 하는게 조금 아쉬운것 같아요.

그래서 CSS 갯수 문제가 발생하는 IE10 미만에서만 작동하도록 하는 옵션을 추가해 보았습니다.다.
이렇게 할 경우 모던 브라우저에서는 그때 그때 필요한것만 다운로드 받을 수 있어서 효과적이지 않을까요?
